### PR TITLE
adding nixpkgs test workflow

### DIFF
--- a/.github/workflows/nixTest.yml
+++ b/.github/workflows/nixTest.yml
@@ -1,0 +1,11 @@
+name: "Test nixpkgs build"
+on: [pull_request, push]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v17
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-build

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,62 @@
+# Nix derivation made to mirror the original hosted at
+# https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/python-modules/deepwave/default.nix
+# to use it for a development environment run
+#
+# > $ nix-shell
+#
+# at the root of the repository. To test the build run:
+#
+# > $ nix-build
+
+with import <nixpkgs> { };
+
+let
+  linePatch = ''
+    import os
+    os.environ['PATH'] = os.environ['PATH'] + ':${ninja}/bin'
+  '';
+in
+python3Packages.buildPythonPackage rec {
+  pname = "deepwave";
+  version = "0.0.13";
+  format = "pyproject";
+
+  src = ./.;
+
+  # unable to find ninja although it is available, most likely because it looks for its pip version
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "ninja" ""
+
+    # Adding ninja to the path forcibly
+    mv src/deepwave/__init__.py tmp
+    echo "${linePatch}" > src/deepwave/__init__.py
+    cat tmp >> src/deepwave/__init__.py
+  '';
+
+  # The source files are compiled at runtime and cached at the
+  # $HOME/.cache folder, so for the check phase it is needed to
+  # have a temporary home. This is also the reason ninja is not
+  # needed at the nativeBuildInputs, since it will only be used
+  # at runtime.
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  propagatedBuildInputs = with python3Packages; [ pytorch pybind11 ];
+
+  checkInputs = [
+    which
+    python3Packages.scipy
+    python3Packages.pytest-xdist
+    python3Packages.pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "deepwave" ];
+
+  meta = with lib; {
+    description = "Wave propagation modules for PyTorch";
+    homepage = "https://github.com/ar4/deepwave";
+    license = licenses.mit;
+    platforms = intersectLists platforms.x86_64 platforms.linux;
+  };
+}


### PR DESCRIPTION
Hello again!

As mentioned in my comment at issue #45, it is possible to add a new workflow that actually tries to build deepwave with nix. This should help avoiding problems the nixpkgs derivation having tests fail with each PR.