### PR TITLE
Support gradient masking in acoustic wave propagation

### DIFF
--- a/src/deepwave/acoustic.c
+++ b/src/deepwave/acoustic.c
@@ -108,6 +108,14 @@
 #define SET_I int64_t const i = x
 #endif
 
+static inline int64_t get_grad_idx(
+    int64_t const *__restrict const gradient_mask_indices, int64_t i) {
+  if (gradient_mask_indices == NULL) {
+    return i;
+  }
+  return gradient_mask_indices[i];
+}
+
 #ifdef _WIN32
 __declspec(dllexport)
 #endif
@@ -473,8 +481,7 @@ __declspec(dllexport)
 
                   if (b_requires_grad_t) {
                     int64_t const grad_idx =
-                        gradient_mask_indices == NULL ? i
-                                                       : gradient_mask_indices[i];
+                        get_grad_idx(gradient_mask_indices, i);
                     if (grad_idx >= 0) {
                       bz_grad_store_1_t[grad_idx] = term_z;
                     }
@@ -501,8 +508,7 @@ __declspec(dllexport)
 
                   if (b_requires_grad_t) {
                     int64_t const grad_idx =
-                        gradient_mask_indices == NULL ? i
-                                                       : gradient_mask_indices[i];
+                        get_grad_idx(gradient_mask_indices, i);
                     if (grad_idx >= 0) {
                       by_grad_store_1_t[grad_idx] = term_y;
                     }
@@ -530,8 +536,7 @@ __declspec(dllexport)
 
                   if (b_requires_grad_t) {
                     int64_t const grad_idx =
-                        gradient_mask_indices == NULL ? i
-                                                       : gradient_mask_indices[i];
+                        get_grad_idx(gradient_mask_indices, i);
                     if (grad_idx >= 0) {
                       bx_grad_store_1_t[grad_idx] = term_x;
                     }
@@ -618,8 +623,7 @@ __declspec(dllexport)
 
                   if (k_requires_grad_t) {
                     int64_t const grad_idx =
-                        gradient_mask_indices == NULL ? i
-                                                       : gradient_mask_indices[i];
+                        get_grad_idx(gradient_mask_indices, i);
                     if (grad_idx >= 0) {
                       k_grad_store_1_t[grad_idx] = div_v;
                     }
@@ -1066,8 +1070,7 @@ __declspec(dllexport)
 
                   if (b_requires_grad_t) {
                     int64_t const grad_idx =
-                        gradient_mask_indices == NULL ? i
-                                                       : gradient_mask_indices[i];
+                        get_grad_idx(gradient_mask_indices, i);
                     if (grad_idx >= 0) {
                       grad_bz_shot[i] -=
                           dt * vz_shot[i] *
@@ -1094,8 +1097,7 @@ __declspec(dllexport)
 
                   if (b_requires_grad_t) {
                     int64_t const grad_idx =
-                        gradient_mask_indices == NULL ? i
-                                                       : gradient_mask_indices[i];
+                        get_grad_idx(gradient_mask_indices, i);
                     if (grad_idx >= 0) {
                       grad_by_shot[i] -=
                           dt * vy_shot[i] *
@@ -1123,8 +1125,7 @@ __declspec(dllexport)
 
                   if (b_requires_grad_t) {
                     int64_t const grad_idx =
-                        gradient_mask_indices == NULL ? i
-                                                       : gradient_mask_indices[i];
+                        get_grad_idx(gradient_mask_indices, i);
                     if (grad_idx >= 0) {
                       grad_bx_shot[i] -=
                           dt * vx_shot[i] *
@@ -1207,8 +1208,7 @@ __declspec(dllexport)
 
                   if (k_requires_grad_t) {
                     int64_t const grad_idx =
-                        gradient_mask_indices == NULL ? i
-                                                       : gradient_mask_indices[i];
+                        get_grad_idx(gradient_mask_indices, i);
                     if (grad_idx >= 0) {
                       grad_k_shot[i] -=
                           dt * p_shot[i] *

--- a/src/deepwave/acoustic.py
+++ b/src/deepwave/acoustic.py
@@ -180,6 +180,7 @@ class Acoustic(torch.nn.Module):
         origin: Optional[Sequence[int]] = None,
         nt: Optional[int] = None,
         model_gradient_sampling_interval: int = 1,
+        gradient_mask: Optional[torch.Tensor] = None,
         freq_taper_frac: float = 0.0,
         time_pad_frac: float = 0.0,
         time_taper: bool = False,
@@ -227,6 +228,7 @@ class Acoustic(torch.nn.Module):
             origin=origin,
             nt=nt,
             model_gradient_sampling_interval=model_gradient_sampling_interval,
+            gradient_mask=gradient_mask,
             freq_taper_frac=freq_taper_frac,
             time_pad_frac=time_pad_frac,
             time_taper=time_taper,
@@ -275,6 +277,7 @@ def acoustic(
     origin: Optional[Sequence[int]] = None,
     nt: Optional[int] = None,
     model_gradient_sampling_interval: int = 1,
+    gradient_mask: Optional[torch.Tensor] = None,
     freq_taper_frac: float = 0.0,
     time_pad_frac: float = 0.0,
     time_taper: bool = False,
@@ -326,6 +329,13 @@ def acoustic(
         origin: Origin of initial wavefields.
         nt: Number of time steps.
         model_gradient_sampling_interval: Interval for gradient sampling.
+        gradient_mask: A boolean Tensor with the same spatial shape as the
+            model, specifying which cells should have gradients computed.
+            Optional. If not provided, gradients will be computed everywhere in
+            the model. If the model is padded internally, an unpadded mask will
+            be padded with False values. True values indicate cells where
+            gradients should be computed, while False values indicate cells
+            where gradients should be set to 0.
         freq_taper_frac: Frequency taper fraction.
         time_pad_frac: Time padding fraction.
         time_taper: Time taper flag.
@@ -377,6 +387,31 @@ def acoustic(
             f"{ndim}d, so locations related to the "
             "y dimension should not be provided."
         )
+
+    if gradient_mask is not None:
+        if not isinstance(gradient_mask, torch.Tensor):
+            raise TypeError("gradient_mask must be a torch.Tensor if provided.")
+        if gradient_mask.dtype != torch.bool:
+            raise TypeError("gradient_mask must be a boolean Tensor.")
+        if gradient_mask.shape != v.shape[-ndim:]:
+            raise RuntimeError(
+                "gradient_mask must match the spatial shape of v and have no batch "
+                "dimension."
+            )
+        if python_backend:
+            raise RuntimeError("gradient_mask is not supported in the Python backend.")
+
+        if (v.requires_grad or rho.requires_grad):
+            # In the backend, gradient masking is applied to the K/B gradient storage and accumulation
+            # but not to v and rho directly. Since buoyancy B depends on neighbor averages of rho, 
+            # autograd gradients on masked cells spread to adjacent rho entries outside the mask, 
+            # causing nonzero gradients there. This violates the API contract. To prevent this, we
+            # disable gradients on masked cells.
+            gradient_mask = gradient_mask.to(
+                device=v.device, dtype=torch.bool, copy=False
+            )
+            v = torch.where(gradient_mask, v, v.detach())
+            rho = torch.where(gradient_mask, rho, rho.detach())
 
     # Prepare initial wavefields list
     initial_wavefields: List[Optional[torch.Tensor]] = []
@@ -533,6 +568,24 @@ def acoustic(
     model_shape = models[0].shape[-ndim:]
     flat_model_shape = int(torch.prod(torch.tensor(model_shape)).item())
 
+    gradient_mask_indices: Optional[torch.Tensor] = None
+    gradient_mask_numel = flat_model_shape
+    if gradient_mask is not None:
+        gradient_mask_indices, gradient_mask_numel = _prepare_gradient_indices(
+            gradient_mask,
+            fd_pad,
+            pml_width,
+            survey_pad,
+            origin,
+            n_shots,
+            ndim,
+            device,
+            source_locations_list,
+            receiver_locations_list,
+            initial_wavefields,
+        )
+        del gradient_mask
+
     for i, (src_amp, src_loc, model) in enumerate(
         zip(source_amplitudes_out, sources_i, models)
     ):
@@ -586,6 +639,8 @@ def acoustic(
             storage_mode,
             storage_path,
             storage_compression,
+            gradient_mask_indices,
+            gradient_mask_numel,
             *models,
             *source_amplitudes_out,
             *sources_i,
@@ -604,6 +659,61 @@ def acoustic(
         )
 
     return outputs
+
+
+def _prepare_gradient_indices(
+    gradient_mask: torch.Tensor,
+    fd_pad: List[int],
+    pml_width: List[int],
+    survey_pad: Optional[Union[int, Sequence[Optional[int]]]],
+    origin: Optional[Sequence[int]],
+    n_shots: int,
+    ndims: int,
+    device: torch.device,
+    source_locations: List[Optional[torch.Tensor]],
+    receiver_locations: List[Optional[torch.Tensor]],
+    wavefields: List[Optional[torch.Tensor]],
+) -> Tuple[torch.Tensor, int]:
+    """
+    Pad/slice mask to the internal domain and build compact indices.
+
+    Produces a spatial-only index tensor aligned with the internally padded
+    model: -1 for masked-out cells and 0..N-1 for masked-in cells (N = number
+    of True entries), along with that count. Enforces a single shared mask
+    (no batch dimension) across all shots.
+    """
+    gradient_mask = gradient_mask.to(device=device, dtype=torch.bool, copy=False)
+    (
+        gradient_mask_prepared,
+        _,
+        _,
+        _,
+    ) = deepwave.common.extract_survey(
+        [gradient_mask],
+        source_locations,
+        receiver_locations,
+        wavefields,
+        survey_pad,
+        origin,
+        fd_pad,
+        pml_width,
+        ["constant"],
+        n_shots,
+        ndims,
+        device,
+        torch.bool,
+    )
+    gradient_mask_prepared = gradient_mask_prepared[0]
+    if gradient_mask_prepared.shape[0] != 1:
+        raise RuntimeError("gradient_mask must not have a batch dimension.")
+    gradient_mask_prepared = gradient_mask_prepared[0].contiguous()
+    mask_flat = gradient_mask_prepared.flatten()
+    indices_flat = torch.full_like(mask_flat, -1, dtype=torch.int64)
+    cumsum = mask_flat.cumsum(dim=0).to(torch.int64) - 1
+    indices_flat = torch.where(mask_flat, cumsum, indices_flat)
+    gradient_mask_indices = indices_flat.reshape_as(gradient_mask_prepared).contiguous()
+    gradient_mask_numel = int(mask_flat.sum().item())
+    return gradient_mask_indices, gradient_mask_numel
 
 
 def zero_edge(tensor: torch.Tensor, fd_pad: int, dim: int) -> torch.Tensor:
@@ -714,6 +824,8 @@ class AcousticForwardFunc(torch.autograd.Function):
         storage_mode_str: str,
         storage_path: str,
         storage_compression: bool,
+        gradient_mask_indices: Optional[torch.Tensor],
+        gradient_mask_numel: int,
         *args: torch.Tensor,
     ) -> Tuple[torch.Tensor, ...]:
         """Performs the forward propagation of the acoustic wave equation."""
@@ -763,6 +875,19 @@ class AcousticForwardFunc(torch.autograd.Function):
 
         device = models[0].device
         dtype = models[0].dtype
+        is_cuda = models[0].is_cuda
+        model_shape = models[0].shape[-ndim:]
+
+        gradient_mask_indices_tensor: Optional[torch.Tensor] = None
+        gradient_mask_indices_ptr: int = 0
+        if gradient_mask_indices is not None:
+            if gradient_mask_indices.shape != model_shape:
+                raise RuntimeError(
+                    "gradient_mask must match the padded model spatial shape and have "
+                    "no batch dimension."
+                )
+            gradient_mask_indices_tensor = gradient_mask_indices.contiguous()
+            gradient_mask_indices_ptr = gradient_mask_indices_tensor.data_ptr()
 
         # Setup storage
         if str(device) == "cpu" and storage_mode_str == "cpu":
@@ -779,13 +904,14 @@ class AcousticForwardFunc(torch.autograd.Function):
         else:
             raise ValueError(f"Invalid storage_mode {storage_mode_str}")
 
-        is_cuda = models[0].is_cuda
-        model_shape = models[0].shape[-ndim:]
+        storage_shape: Tuple[int, ...] = tuple(model_shape)
+        if gradient_mask_indices_tensor is not None:
+            storage_shape = (gradient_mask_numel,)
         n_sources_per_shot_list = [locs.numel() // n_shots for locs in sources_i]
         n_receivers_per_shot_list = [locs.numel() // n_shots for locs in receivers_i]
 
         storage_manager = deepwave.common.StorageManager(
-            model_shape,
+            storage_shape,
             dtype,
             n_shots,
             nt,
@@ -821,6 +947,7 @@ class AcousticForwardFunc(torch.autograd.Function):
             ctx.backward_callback = backward_callback
             ctx.callback_frequency = callback_frequency
             ctx.storage_manager = storage_manager
+            ctx.gradient_mask_indices = gradient_mask_indices_tensor
 
         fd_pad = accuracy // 2
         fd_pad_list = [fd_pad, fd_pad - 1] * ndim
@@ -931,6 +1058,8 @@ class AcousticForwardFunc(torch.autograd.Function):
                         *[amp.data_ptr() for amp in source_amplitudes],
                         *[w.data_ptr() for w in wavefields],
                         *storage_manager.storage_ptrs,
+                        gradient_mask_indices_ptr,
+                        storage_manager.num_elements_per_shot,
                         *[amp.data_ptr() for amp in receiver_amplitudes],
                         *[p.data_ptr() for p in pml_profiles],
                         *[loc.data_ptr() for loc in sources_i],
@@ -975,6 +1104,12 @@ class AcousticForwardFunc(torch.autograd.Function):
         # Unpack
         grid_spacing = ctx.grid_spacing
         ndim = len(grid_spacing)
+        gradient_mask_indices = ctx.gradient_mask_indices
+        gradient_mask_indices_ptr = (
+            0
+            if gradient_mask_indices is None
+            else gradient_mask_indices.data_ptr()
+        )
 
         grad_wavefields = list(args[: -ndim - 1])
         grad_r = list(args[-ndim - 1 :])
@@ -1151,6 +1286,8 @@ class AcousticForwardFunc(torch.autograd.Function):
                         *[field.data_ptr() for field in grad_wavefields],
                         *[field.data_ptr() for field in aux_wavefields],
                         *storage_manager.storage_ptrs,
+                        gradient_mask_indices_ptr,
+                        storage_manager.num_elements_per_shot,
                         *[g.data_ptr() for g in grad_f_list],
                         *[g.data_ptr() for g in grad_models],
                         *grad_models_tmp_ptr,
@@ -1212,7 +1349,7 @@ class AcousticForwardFunc(torch.autograd.Function):
             *(slice(fd_pad, shape - (fd_pad - 1)) for shape in model_shape),
         )
         return tuple(
-            [None] * 14
+            [None] * 16
             + grad_models
             + grad_f_list
             + [None] * num_source_types  # sources_i
@@ -1316,11 +1453,15 @@ def acoustic_python(
     storage_mode_str: str,
     storage_path: str,
     storage_compression: bool,
+    gradient_mask_indices: Optional[torch.Tensor],
+    gradient_mask_numel: int,
     *args: torch.Tensor,
 ) -> Tuple[torch.Tensor, ...]:
     """Python backend for acoustic wave propagation."""
     if backward_callback is not None:
         raise RuntimeError("backward_callback is not supported in the Python backend.")
+    if gradient_mask_indices is not None:
+        raise RuntimeError("gradient_mask is not supported in the Python backend.")
     if storage_mode_str != "device":
         raise RuntimeError(
             "Specifying storage mode is not supported in Python backend."

--- a/src/deepwave/backend_utils.py
+++ b/src/deepwave/backend_utils.py
@@ -451,6 +451,8 @@ def get_acoustic_forward_template(ndim: int) -> List[Any]:
     args += [c_void_p] * (1 + 3 * ndim)  # p, v, phi, psi
     args += [c_void_p] * 5  # k_store_1a, k_store_1b, k_store_2, k_store_3, k_filenames
     args += [c_void_p] * (5 * ndim)  # b_store...
+    args += [c_void_p]  # gradient_mask_indices
+    args += [c_int64]  # grad_shot_numel
     args += [c_void_p] * (1 + ndim)  # receiver_amplitudes
     args += [c_void_p] * (4 * ndim)  # a, b, ah, bh
     args += [c_void_p] * (1 + ndim)  # sources_i
@@ -482,6 +484,8 @@ def get_acoustic_backward_template(ndim: int) -> List[Any]:
     args += [c_void_p] * (ndim)  # psin
     args += [c_void_p] * 5  # k_store
     args += [c_void_p] * (5 * ndim)  # b_store
+    args += [c_void_p]  # gradient_mask_indices
+    args += [c_int64]  # grad_shot_numel
     args += [c_void_p] * (1 + ndim)  # grad_f
     args += [c_void_p] * (2 + 2 * ndim)  # grad_k, grad_b, grad_k_thread, grad_b_thread
     args += [c_void_p] * (4 * ndim)  # a, b, ah, bh


### PR DESCRIPTION
# Motivation
For some inversion problems, a subset of the true density/velocity model is known. In these use cases, we only need to solve for the subset of the model parameters that are unknown. Large memory savings are possible from only storing the gradient where necessary.

This pull request introduces a gradient mask parameter to the acoustic wave propagator that allows the CUDA kernel to compute gradients only for a subset of grid points using a sparse gradient mask index:
```
        gradient_mask: A boolean Tensor with the same spatial shape as the
            model, specifying which cells should have gradients computed.
            Optional. If not provided, gradients will be computed everywhere in
            the model. If the model is padded internally, an unpadded mask will
            be padded with False values. True values indicate cells where
            gradients should be computed, while False values indicate cells
            where gradients should be set to 0.
```

# Test Plan
Added new unit tests:
1. Test that gradient masking reduces memory requirements.
2. Test that the gradient mask zeros gradients outside the mask.
3. Test that providing no gradient mask computes the gradient everywhere.
4. Test that gradient masking is not supported when using the python backend.

```
pip install . && PYTHONPATH= python -m pytest
```

In addition, a similar version of this code has been used internally at my work for full waveform inversion with a computational domain that cannot fit in H200 gpu memory without gradient masking.